### PR TITLE
Fix URL parsing for configuration dumping

### DIFF
--- a/buildarr_sonarr/cli.py
+++ b/buildarr_sonarr/cli.py
@@ -22,8 +22,8 @@ from __future__ import annotations
 import functools
 
 from getpass import getpass
-from urllib.parse import urlparse
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
 import click
 

--- a/buildarr_sonarr/cli.py
+++ b/buildarr_sonarr/cli.py
@@ -23,13 +23,16 @@ import functools
 
 from getpass import getpass
 from urllib.parse import urlparse
+from typing import TYPE_CHECKING
 
 import click
-import click_params  # type: ignore[import]
 
 from .config import SonarrInstanceConfig
 from .manager import SonarrManager
 from .secrets import SonarrSecrets
+
+if TYPE_CHECKING:
+    from urllib.parse import ParseResult as Url
 
 HOSTNAME_PORT_TUPLE_LENGTH = 2
 
@@ -49,7 +52,7 @@ def sonarr():
         "The configuration is dumped to standard output in Buildarr-compatible YAML format."
     ),
 )
-@click.argument("url", type=click_params.URL)
+@click.argument("url", type=urlparse)
 @click.option(
     "-k",
     "--api-key",
@@ -58,15 +61,14 @@ def sonarr():
     default=functools.partial(getpass, "Sonarr instance API key: "),
     help="API key of the Sonarr instance. The user will be prompted if undefined.",
 )
-def dump_config(url: str, api_key: str) -> int:
+def dump_config(url: Url, api_key: str) -> int:
     """
     Dump configuration from a remote Sonarr instance.
     The configuration is dumped to standard output in Buildarr-compatible YAML format.
     """
 
-    url_obj = urlparse(url)
-    protocol = url_obj.scheme
-    hostname_port = url_obj.netloc.split(":", 1)
+    protocol = url.scheme
+    hostname_port = url.netloc.split(":", 1)
     hostname = hostname_port[0]
     port = (
         int(hostname_port[1])

--- a/poetry.lock
+++ b/poetry.lock
@@ -1011,4 +1011,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "8638c6f8ad94c290b4646794b0d5c196033efc3e6473bf1d097008909c1ecdec"
+content-hash = "30da49d4040cfbe39879f8f17d4bb06d96ab07ff592c026282ec188e7460f820"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ packages = [{include = "buildarr_sonarr"}]
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
 buildarr = ">=0.5.0,<0.7.0"
+json5 = ">=0.9.7"
 
 [tool.poetry.group.dev.dependencies]
 black = "23.7.0"


### PR DESCRIPTION
* Use Python's `urlparse` function to parse the Sonarr instance URL, accepting any valid URL of any hostname/address
* Add explicit `json5` dependency to the plugin dependencies, instead of relying on the implicit dependency from Buildarr Core