### PR TITLE
Add the `TV` group as a selectable Newznab/Torznab category

### DIFF
--- a/buildarr_sonarr/config/indexers.py
+++ b/buildarr_sonarr/config/indexers.py
@@ -39,6 +39,7 @@ class NabCategory(BaseEnum):
     Newznab/Torznab category enumeration.
     """
 
+    TV = 5000
     TV_WEBDL = 5010
     TV_FOREIGN = 5020
     TV_SD = 5030


### PR DESCRIPTION
`TV` should be allowed to be specified to Buildarr to enable allowing all TV category types.