### PR TITLE
Auto-fetch API key when dumping configuration if not specified

### DIFF
--- a/buildarr_sonarr/api.py
+++ b/buildarr_sonarr/api.py
@@ -293,7 +293,7 @@ def api_error(
     """
 
     error_message = (
-        f"Unexpected response with status code {response.status_code} from from '{method} {url}':"
+        f"Unexpected response with status code {response.status_code} from '{method} {url}':"
     )
     if parse_response:
         res_json = response.json()
@@ -330,6 +330,10 @@ def _api_error(res_json: Any) -> str:
             pass
         try:
             return f"{res_json['message']}\n{res_json['description']}"
+        except KeyError:
+            pass
+        try:
+            return res_json["error"]
         except KeyError:
             pass
         return res_json["message"]


### PR DESCRIPTION
* When dumping Sonarr instance configurations, try to auto-fetch the API key of the Sonarr instance if it is left blank at the prompt
* Minor refactoring of the `dump-config` CLI command and the secrets model functions
* Improve API error handling and fix bad grammar in error messages