### PR TITLE
Add Sonarr instance URL base support

### DIFF
--- a/buildarr_sonarr/cli.py
+++ b/buildarr_sonarr/cli.py
@@ -78,12 +78,14 @@ def dump_config(url: Url, api_key: str) -> int:
         if len(hostname_port) == HOSTNAME_PORT_TUPLE_LENGTH
         else (443 if protocol == "https" else 80)
     )
+    url_base = url.path
 
     instance_config = SonarrInstanceConfig(
         **{  # type: ignore[arg-type]
             "hostname": hostname,
             "port": port,
             "protocol": protocol,
+            "url_base": url_base,
         },
     )
 
@@ -95,6 +97,7 @@ def dump_config(url: Url, api_key: str) -> int:
                 hostname=hostname,
                 port=port,
                 protocol=protocol,
+                url_base=url_base,
                 api_key=api_key if api_key else None,
             ),
         )

--- a/buildarr_sonarr/secrets.py
+++ b/buildarr_sonarr/secrets.py
@@ -20,19 +20,17 @@ Sonarr plugin secrets file model.
 from __future__ import annotations
 
 from http import HTTPStatus
-from typing import TYPE_CHECKING, cast
-from urllib.parse import urlparse
+from typing import TYPE_CHECKING, Any, Dict, Optional, cast
 
 from buildarr.secrets import SecretsPlugin
 from buildarr.types import NonEmptyStr, Port
+from pydantic import validator
 
 from .api import api_get, get_initialize_js
 from .exceptions import SonarrAPIError, SonarrSecretsUnauthorizedError
 from .types import SonarrApiKey, SonarrProtocol
 
 if TYPE_CHECKING:
-    from typing import Optional
-
     from typing_extensions import Self
 
     from .config import SonarrConfig
@@ -54,29 +52,17 @@ class SonarrSecrets(_SonarrSecrets):
     hostname: NonEmptyStr
     port: Port
     protocol: SonarrProtocol
+    url_base: Optional[str]
     api_key: SonarrApiKey
+    version: NonEmptyStr
 
     @property
     def host_url(self) -> str:
-        return f"{self.protocol}://{self.hostname}:{self.port}"
+        return f"{self.protocol}://{self.hostname}:{self.port}{self.url_base or ''}"
 
-    @classmethod
-    def from_url(cls, base_url: str, api_key: str) -> Self:
-        url_obj = urlparse(base_url)
-        hostname_port = url_obj.netloc.rsplit(":", 1)
-        hostname = hostname_port[0]
-        protocol = url_obj.scheme
-        port = (
-            int(hostname_port[1])
-            if len(hostname_port) > 1
-            else (443 if protocol == "https" else 80)
-        )
-        return cls(
-            hostname=cast(NonEmptyStr, hostname),
-            port=cast(Port, port),
-            protocol=cast(SonarrProtocol, protocol),
-            api_key=cast(SonarrApiKey, api_key),
-        )
+    @validator("url_base")
+    def validate_url_base(cls, value: Optional[str]) -> Optional[str]:
+        return f"/{value.strip('/')}" if value and value.strip("/") else None
 
     @classmethod
     def get(cls, config: SonarrConfig) -> Self:
@@ -84,6 +70,7 @@ class SonarrSecrets(_SonarrSecrets):
             hostname=config.hostname,
             port=config.port,
             protocol=config.protocol,
+            url_base=config.url_base,
             api_key=config.api_key.get_secret_value() if config.api_key else None,
         )
 
@@ -93,9 +80,11 @@ class SonarrSecrets(_SonarrSecrets):
         hostname: str,
         port: int,
         protocol: str,
+        url_base: Optional[str] = None,
         api_key: Optional[str] = None,
     ) -> Self:
-        host_url = f"{protocol}://{hostname}:{port}"
+        _url_base = cls.validate_url_base(url_base)
+        host_url = f"{protocol}://{hostname}:{port}{_url_base or ''}"
         if not api_key:
             try:
                 initialize_js = get_initialize_js(host_url)
@@ -114,19 +103,46 @@ class SonarrSecrets(_SonarrSecrets):
                     raise
             else:
                 api_key = initialize_js["apiKey"]
+        try:
+            system_status = cast(
+                Dict[str, Any],
+                api_get(host_url, "/api/v3/system/status", api_key=api_key),
+            )
+        except SonarrAPIError as err:
+            if err.status_code == HTTPStatus.UNAUTHORIZED:
+                raise SonarrSecretsUnauthorizedError(
+                    (
+                        f"Incorrect API key for the Sonarr instance at '{host_url}'. "
+                        "Please check that the API key is set correctly in the Buildarr "
+                        "configuration, and that it is set to the value as shown in "
+                        "'Settings -> General -> API Key' on the Radarr instance."
+                    ),
+                ) from None
+            else:
+                raise
+        try:
+            version = cast(NonEmptyStr, system_status["version"])
+        except KeyError:
+            raise SonarrSecretsUnauthorizedError(
+                f"Unable to find Sonarr version in system status metadata: {system_status}",
+            ) from None
+        except TypeError as err:
+            raise SonarrSecretsUnauthorizedError(
+                (
+                    f"Unable to parse Sonarr system status metadata: {err} "
+                    f"(metadata object: {system_status})"
+                ),
+            ) from None
         return cls(
             hostname=cast(NonEmptyStr, hostname),
             port=cast(Port, port),
             protocol=cast(SonarrProtocol, protocol),
+            url_base=_url_base,
             api_key=cast(SonarrApiKey, api_key),
+            version=version,
         )
 
     def test(self) -> bool:
-        try:
-            api_get(self, "/api/v3/system/status")
-            return True
-        except SonarrAPIError as err:
-            if err.status_code == HTTPStatus.UNAUTHORIZED:
-                return False
-            else:
-                raise
+        # We already perform API requests as part of instantiating the secrets object.
+        # If the object exists, then the connection test is already successful.
+        return True

--- a/docs/configuration/host.md
+++ b/docs/configuration/host.md
@@ -6,6 +6,7 @@
         - hostname
         - port
         - protocol
+        - url_base
         - api_key
         - version
         - settings


### PR DESCRIPTION
https://github.com/buildarr/buildarr-sonarr/issues/43

* Add the `url_base` host configuration attribute.
* When dumping host configurations, use the provided path as the URL base.
* Read and store the instance version as secrets metadata (instead of fetching it in a separate API request when creating the instance configuration). Necessary for future Sonarr V4 support.