### PR TITLE
Fix remote path mapping checking edge cases

### DIFF
--- a/buildarr_sonarr/config/download_clients/remote_path_mappings.py
+++ b/buildarr_sonarr/config/download_clients/remote_path_mappings.py
@@ -202,17 +202,18 @@ class SonarrRemotePathMappingsSettingsConfig(SonarrConfigBase):
         remote_rpms: Dict[Tuple[str, str, str], RemotePathMapping] = {
             (rpm.host, rpm.remote_path, rpm.local_path): rpm for rpm in remote.definitions
         }
+        logger.debug("remote_rpms = %s", remote_rpms)
         # Handle managed remote path mappings.
         for i, rpm in enumerate(self.definitions):
             rpm_tree = f"{tree}.definitions[{i}]"
             rpm_tuple = (rpm.host, rpm.remote_path, rpm.local_path)
+            logger.debug("rpm_tuple = %s", rpm_tuple)
             # If the remote path mapping should exist, check that it does,
             # and if not, create it.
             if rpm.ensure == Ensure.present:
                 if rpm_tuple in remote_rpms:
                     logger.debug("%s: %s (exists)", rpm_tree, repr(rpm))
                 else:
-                    logger.info("%s: %s -> (created)", rpm_tree, repr(rpm))
                     rpm._create_remote(tree=rpm_tree, secrets=secrets)
                     changed = True
             # If the remote path mapping should not exist, check that it does not

--- a/buildarr_sonarr/config/download_clients/remote_path_mappings.py
+++ b/buildarr_sonarr/config/download_clients/remote_path_mappings.py
@@ -67,16 +67,18 @@ class RemotePathMapping(SonarrConfigBase):
     """
     Root path to the directory that the download client accesses.
 
-    *Changed in version 0.6.4:* Path checking is now case-insensitive, and will match paths
-    whether or not a trailing `/` (`\\` for Windows paths) is defined in the configuration.
+    *Changed in version 0.6.4:* Path checking will now match paths
+    whether or not the defined path ends in a trailing slash.
+    Path checking on Windows paths is now case-insensitive.
     """
 
     local_path: OSAgnosticPath
     """
     The path that Sonarr should use to access the remote path locally.
 
-    *Changed in version 0.6.4:* Path checking is now case-insensitive, and will match paths
-    whether or not a trailing `/` (`\\` for Windows paths) is defined in the configuration.
+    *Changed in version 0.6.4:* Path checking will now match paths
+    whether or not the defined path ends in a trailing slash.
+    Path checking on Windows paths is now case-insensitive.
     """
 
     ensure: Ensure = Ensure.present
@@ -98,7 +100,9 @@ class RemotePathMapping(SonarrConfigBase):
 
     @validator("remote_path", "local_path")
     def add_trailing_slash(cls, value: OSAgnosticPath) -> OSAgnosticPath:
-        return value + ("\\" if value.is_windows() else "/")
+        if value.is_windows():
+            return (value + "\\") if not value.endswith("\\\\") else value
+        return (value + "/") if not value.endswith("/") else value
 
     @classmethod
     def _from_remote(cls, remote_attrs: Mapping[str, Any]) -> Self:

--- a/buildarr_sonarr/config/download_clients/remote_path_mappings.py
+++ b/buildarr_sonarr/config/download_clients/remote_path_mappings.py
@@ -66,11 +66,17 @@ class RemotePathMapping(SonarrConfigBase):
     remote_path: OSAgnosticPath
     """
     Root path to the directory that the download client accesses.
+
+    *Changed in version 0.6.4:* Path checking is now case-insensitive, and will match paths
+    whether or not a trailing `/` (`\\` for Windows paths) is defined in the configuration.
     """
 
     local_path: OSAgnosticPath
     """
     The path that Sonarr should use to access the remote path locally.
+
+    *Changed in version 0.6.4:* Path checking is now case-insensitive, and will match paths
+    whether or not a trailing `/` (`\\` for Windows paths) is defined in the configuration.
     """
 
     ensure: Ensure = Ensure.present
@@ -86,8 +92,8 @@ class RemotePathMapping(SonarrConfigBase):
 
     _remote_map: List[RemoteMapEntry] = [
         ("host", "host", {}),
-        ("remote_path", "remotePath", {"encoder": lambda x: str(x)}),
-        ("local_path", "localPath", {"encoder": lambda x: str(x)}),
+        ("remote_path", "remotePath", {}),
+        ("local_path", "localPath", {}),
     ]
 
     @validator("remote_path", "local_path")

--- a/buildarr_sonarr/config/download_clients/remote_path_mappings.py
+++ b/buildarr_sonarr/config/download_clients/remote_path_mappings.py
@@ -70,7 +70,7 @@ class RemotePathMapping(SonarrConfigBase):
     """
     Root path to the directory that the download client accesses.
 
-    *Changed in version 0.6.4:* Path checking will now match paths
+    *Changed in version 0.6.4*: Path checking will now match paths
     whether or not the defined path ends in a trailing slash.
     Path checking on Windows paths is now case-insensitive.
     """
@@ -79,7 +79,7 @@ class RemotePathMapping(SonarrConfigBase):
     """
     The path that Sonarr should use to access the remote path locally.
 
-    *Changed in version 0.6.4:* Path checking will now match paths
+    *Changed in version 0.6.4*: Path checking will now match paths
     whether or not the defined path ends in a trailing slash.
     Path checking on Windows paths is now case-insensitive.
     """

--- a/buildarr_sonarr/config/download_clients/remote_path_mappings.py
+++ b/buildarr_sonarr/config/download_clients/remote_path_mappings.py
@@ -267,7 +267,11 @@ class SonarrRemotePathMappingsSettingsConfig(SonarrConfigBase):
     def _delete_remote(self, tree: str, secrets: SonarrSecrets, remote: Self) -> bool:
         changed = False
         remote_rpm_ids: Dict[Tuple[str, OSAgnosticPath, OSAgnosticPath], int] = {
-            (rpm["host"], rpm["remotePath"], rpm["localPath"]): rpm["id"]
+            (
+                rpm["host"],
+                OSAgnosticPath(rpm["remotePath"]),
+                OSAgnosticPath(rpm["localPath"]),
+            ): rpm["id"]
             for rpm in api_get(secrets, "/api/v3/remotepathmapping")
         }
         local_rpms: Dict[Tuple[str, OSAgnosticPath, OSAgnosticPath], RemotePathMapping] = {

--- a/buildarr_sonarr/config/download_clients/remote_path_mappings.py
+++ b/buildarr_sonarr/config/download_clients/remote_path_mappings.py
@@ -235,12 +235,10 @@ class SonarrRemotePathMappingsSettingsConfig(SonarrConfigBase):
         remote_rpms: Dict[Tuple[str, OSAgnosticPath, OSAgnosticPath], RemotePathMapping] = {
             (rpm.host, rpm.remote_path, rpm.local_path): rpm for rpm in remote.definitions
         }
-        logger.debug("remote_rpms = %s", remote_rpms)
         # Handle managed remote path mappings.
         for i, rpm in enumerate(self.definitions):
             rpm_tree = f"{tree}.definitions[{i}]"
             rpm_tuple = (rpm.host, rpm.remote_path, rpm.local_path)
-            logger.debug("rpm_tuple = %s", rpm_tuple)
             # If the remote path mapping should exist, check that it does,
             # and if not, create it.
             if rpm.ensure == Ensure.present:

--- a/buildarr_sonarr/config/download_clients/remote_path_mappings.py
+++ b/buildarr_sonarr/config/download_clients/remote_path_mappings.py
@@ -86,8 +86,8 @@ class RemotePathMapping(SonarrConfigBase):
 
     _remote_map: List[RemoteMapEntry] = [
         ("host", "host", {}),
-        ("remote_path", "remotePath", {"encoder": lambda x: x.path}),
-        ("local_path", "localPath", {"encoder": lambda x: x.path}),
+        ("remote_path", "remotePath", {"encoder": lambda x: str(x)}),
+        ("local_path", "localPath", {"encoder": lambda x: str(x)}),
     ]
 
     @validator("remote_path", "local_path")

--- a/buildarr_sonarr/config/download_clients/remote_path_mappings.py
+++ b/buildarr_sonarr/config/download_clients/remote_path_mappings.py
@@ -48,6 +48,9 @@ class Ensure(BaseEnum):
     present = "present"
     absent = "absent"
 
+    def __repr__(self) -> str:
+        return repr(self.name)
+
 
 class RemotePathMapping(SonarrConfigBase):
     """

--- a/buildarr_sonarr/types.py
+++ b/buildarr_sonarr/types.py
@@ -22,50 +22,31 @@ from __future__ import annotations
 import re
 
 from pathlib import PureWindowsPath
-from typing import Any, Callable, Generator, Literal
+from typing import Any, Literal
 
 from pydantic import SecretStr
-from typing_extensions import Self
 
 SonarrProtocol = Literal["http", "https"]
 
 
-class OSAgnosticPath:
-    def __init__(self, path: Any) -> None:
-        self.path = str(path)
-
+class OSAgnosticPath(str):
     def is_windows(self) -> bool:
-        return bool(re.match(r"^[A-Za-z]:\\", self.path) or self.path.startswith(r"\\"))
+        return bool(re.match(r"^[A-Za-z]:", self) or self.startswith(r"\\"))
 
     def is_posix(self) -> bool:
         return not self.is_windows()
 
+    def __add__(self, other: Any) -> OSAgnosticPath:
+        return OSAgnosticPath(super().__add__(other))
+
     def __eq__(self, other: Any) -> bool:
         try:
-            return PureWindowsPath(self.path) == PureWindowsPath(
-                other.path if isinstance(other, OSAgnosticPath) else other,
-            )
+            return PureWindowsPath(self) == PureWindowsPath(other)
         except TypeError:
             return False
 
-    def __add__(self, other: Any) -> OSAgnosticPath:
-        return OSAgnosticPath(
-            self.path + (other.path if isinstance(other, OSAgnosticPath) else other),
-        )
-
-    def __repr__(self) -> str:
-        return self.path
-
     def __hash__(self) -> int:
-        return hash(self.path)
-
-    @classmethod
-    def __get_validators__(cls) -> Generator[Callable[[Any], Self], None, None]:
-        yield cls.validate
-
-    @classmethod
-    def validate(cls, value: Any) -> Self:
-        return cls(value)
+        return hash(PureWindowsPath(self))
 
 
 class SonarrApiKey(SecretStr):

--- a/buildarr_sonarr/types.py
+++ b/buildarr_sonarr/types.py
@@ -19,11 +19,44 @@ Sonarr plugin type hints.
 
 from __future__ import annotations
 
-from typing import Literal
+import re
+
+from pathlib import PureWindowsPath
+from typing import Any, Literal
 
 from pydantic import SecretStr
 
 SonarrProtocol = Literal["http", "https"]
+
+
+class OSAgnosticPath:
+    def __init__(self, path: str) -> None:
+        self.path = str(path)
+
+    def is_windows(self) -> bool:
+        return bool(re.match("[A-Za-z]:\\", self.path) or self.path.startswith("\\\\"))
+
+    def is_posix(self) -> bool:
+        return not self.is_windows()
+
+    def __eq__(self, other: Any) -> bool:
+        try:
+            return PureWindowsPath(self.path) == PureWindowsPath(
+                other.path if isinstance(other, OSAgnosticPath) else other,
+            )
+        except TypeError:
+            return False
+
+    def __add__(self, other: Any) -> OSAgnosticPath:
+        return OSAgnosticPath(
+            self.path + (other.path if isinstance(self, OSAgnosticPath) else other),
+        )
+
+    def __repr__(self) -> str:
+        return self.path
+
+    def __hash__(self) -> int:
+        return hash(self.path)
 
 
 class SonarrApiKey(SecretStr):

--- a/buildarr_sonarr/types.py
+++ b/buildarr_sonarr/types.py
@@ -22,9 +22,10 @@ from __future__ import annotations
 import re
 
 from pathlib import PureWindowsPath
-from typing import Any, Literal
+from typing import Any, Callable, Generator, Literal
 
 from pydantic import SecretStr
+from typing_extensions import Self
 
 SonarrProtocol = Literal["http", "https"]
 
@@ -47,6 +48,14 @@ class OSAgnosticPath(str):
 
     def __hash__(self) -> int:
         return hash(PureWindowsPath(self))
+
+    @classmethod
+    def __get_validators__(cls) -> Generator[Callable[[Any], Self], None, None]:
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value: Any) -> Self:
+        return cls(value)
 
 
 class SonarrApiKey(SecretStr):

--- a/buildarr_sonarr/types.py
+++ b/buildarr_sonarr/types.py
@@ -35,7 +35,7 @@ class OSAgnosticPath:
         self.path = str(path)
 
     def is_windows(self) -> bool:
-        return bool(re.match("[A-Za-z]:\\", self.path) or self.path.startswith("\\\\"))
+        return bool(re.match(r"^[A-Za-z]:\\", self.path) or self.path.startswith("\\\\"))
 
     def is_posix(self) -> bool:
         return not self.is_windows()

--- a/buildarr_sonarr/types.py
+++ b/buildarr_sonarr/types.py
@@ -35,7 +35,7 @@ class OSAgnosticPath:
         self.path = str(path)
 
     def is_windows(self) -> bool:
-        return bool(re.match(r"^[A-Za-z]:\\", self.path) or self.path.startswith("\\\\"))
+        return bool(re.match(r"^[A-Za-z]:\\", self.path) or self.path.startswith(r"\\"))
 
     def is_posix(self) -> bool:
         return not self.is_windows()
@@ -50,7 +50,7 @@ class OSAgnosticPath:
 
     def __add__(self, other: Any) -> OSAgnosticPath:
         return OSAgnosticPath(
-            self.path + (other.path if isinstance(self, OSAgnosticPath) else other),
+            self.path + (other.path if isinstance(other, OSAgnosticPath) else other),
         )
 
     def __repr__(self) -> str:

--- a/buildarr_sonarr/types.py
+++ b/buildarr_sonarr/types.py
@@ -32,7 +32,7 @@ SonarrProtocol = Literal["http", "https"]
 
 class OSAgnosticPath(str):
     def is_windows(self) -> bool:
-        return bool(re.match(r"^[A-Za-z]:", self) or self.startswith(r"\\"))
+        return bool(re.match(r"^[A-Za-z]:", self) or self.startswith("\\\\"))
 
     def is_posix(self) -> bool:
         return not self.is_windows()

--- a/buildarr_sonarr/types.py
+++ b/buildarr_sonarr/types.py
@@ -22,15 +22,16 @@ from __future__ import annotations
 import re
 
 from pathlib import PureWindowsPath
-from typing import Any, Literal
+from typing import Any, Callable, Generator, Literal
 
 from pydantic import SecretStr
+from typing_extensions import Self
 
 SonarrProtocol = Literal["http", "https"]
 
 
 class OSAgnosticPath:
-    def __init__(self, path: str) -> None:
+    def __init__(self, path: Any) -> None:
         self.path = str(path)
 
     def is_windows(self) -> bool:
@@ -57,6 +58,14 @@ class OSAgnosticPath:
 
     def __hash__(self) -> int:
         return hash(self.path)
+
+    @classmethod
+    def __get_validators__(cls) -> Generator[Callable[[Any], Self], None, None]:
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value: Any) -> Self:
+        return cls(value)
 
 
 class SonarrApiKey(SecretStr):

--- a/buildarr_sonarr/types.py
+++ b/buildarr_sonarr/types.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import re
 
-from pathlib import PureWindowsPath
+from pathlib import PurePosixPath, PureWindowsPath
 from typing import Any, Callable, Generator, Literal
 
 from pydantic import SecretStr
@@ -42,12 +42,18 @@ class OSAgnosticPath(str):
 
     def __eq__(self, other: Any) -> bool:
         try:
-            return PureWindowsPath(self) == PureWindowsPath(other)
+            if self.is_windows():
+                return PureWindowsPath(self) == PureWindowsPath(other)
+            else:
+                return PurePosixPath(self) == PurePosixPath(other)
         except TypeError:
             return False
 
     def __hash__(self) -> int:
-        return hash(PureWindowsPath(self))
+        if self.is_windows():
+            return hash(PureWindowsPath(self))
+        else:
+            return hash(PurePosixPath(self))
 
     @classmethod
     def __get_validators__(cls) -> Generator[Callable[[Any], Self], None, None]:


### PR DESCRIPTION
#49

* Add a validator to the `remote_path` and `local_path` fields that ensures a trailing slash is added to the values of the, if the values defined in the configuration don't have them. This matches Sonarr's behaviour when setting these values, and fixes an issue where Buildarr would always try to add remote path mappings without trailing spaces in the paths to Sonarr, even if they already existed.
* Switch the `remote_path` and `local_path` fields for remote path mappings to a custom `OSAgnosticPath` type, that semi-transparently handles differences between POSIX and Windows paths. Windows paths will be compared case-insensitively.
* Update resource management logging for remote path mappings to the latest standards for Buildarr, and remove extraneous logging.