### PR TITLE
Set `field_default` for the SABnzbd download client `url_base` field

### DIFF
--- a/buildarr_sonarr/config/download_clients/download_clients.py
+++ b/buildarr_sonarr/config/download_clients/download_clients.py
@@ -781,7 +781,12 @@ class SabnzbdDownloadClient(UsenetDownloadClient):
         (
             "url_base",
             "urlBase",
-            {"is_field": True, "decoder": lambda v: v or None, "encoder": lambda v: v or ""},
+            {
+                "is_field": True,
+                "field_default": None,
+                "decoder": lambda v: v or None,
+                "encoder": lambda v: v or "",
+            },
         ),
         ("api_key", "apiKey", {"is_field": True}),
         (


### PR DESCRIPTION
#50

If a SABnzbd download client does not have a URL base defined in Sonarr, it does not include a default value in the API response.