### PR TITLE
Enable Python 3.12 testing in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,8 +58,7 @@ jobs:
             - "3.9"
             - "3.10"
             - "3.11"
-            # TODO: Re-enable when upgrading to Buildarr v0.8.
-            # - "3.12"
+            - "3.12"
     runs-on: ${{ matrix.operating_system }}
     steps:
       - name: Clone full tree, and checkout branch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,6 @@ minversion = "6.0"
 addopts = "--color=yes --cov=buildarr_sonarr --cov-config=pyproject.toml --cov-report=html:cover --cov-report=term --cov-report=xml:coverage.xml --junit-xml=rspec.xml -r A --showlocals --verbosity=3"
 filterwarnings = [
     "error",
-    "ignore::DeprecationWarning",  # TODO: Remove this when upgrading to Buildarr v0.8.
 ]
 testpaths = [
     "tests",


### PR DESCRIPTION
Buildarr v0.8 supports Python 3.12, so we can now enable automated testing using it.