### PR TITLE
Fix/initialize json

### DIFF
--- a/buildarr_sonarr/api.py
+++ b/buildarr_sonarr/api.py
@@ -42,7 +42,9 @@ logger = getLogger(__name__)
 INITIALIZE_JS_RES_PATTERN = re.compile(r"(?s)^window\.Sonarr = ({.*});$")
 
 
-def get_initialize_page(host_url: str, api_key: Optional[str] = None, file_extension: str = "js") -> Dict[str, Any]:
+def get_initialize_page(
+    host_url: str, api_key: Optional[str] = None, file_extension: str = "js"
+) -> Dict[str, Any]:
     """
     Get the Sonarr session initialisation metadata, including the API key.
 
@@ -81,7 +83,7 @@ def get_initialize_page(host_url: str, api_key: Optional[str] = None, file_exten
             f"Unable to retrieve '{url}': {error_message}",
             status_code=status_code,
         )
-        
+
     logger.debug("GET %s -> status_code=%i res=%s", url, res.status_code, repr(res.text))
     if file_extension == "json":
         return res.json()

--- a/buildarr_sonarr/api.py
+++ b/buildarr_sonarr/api.py
@@ -42,7 +42,7 @@ logger = getLogger(__name__)
 INITIALIZE_JS_RES_PATTERN = re.compile(r"(?s)^window\.Sonarr = ({.*});$")
 
 
-def get_initialize_js(host_url: str, api_key: Optional[str] = None, file_extension: str = "js") -> Dict[str, Any]:
+def get_initialize_page(host_url: str, api_key: Optional[str] = None, file_extension: str = "js") -> Dict[str, Any]:
     """
     Get the Sonarr session initialisation metadata, including the API key.
 
@@ -73,7 +73,7 @@ def get_initialize_js(host_url: str, api_key: Optional[str] = None, file_extensi
             error_message = "Unauthorized"
         elif res.status_code == HTTPStatus.NOT_FOUND and file_extension == "js":
             logger.debug("Initialize page not found, perhaps running Sonarr v4? Retrying...")
-            return get_initialize_js(host_url, api_key, "json")
+            return get_initialize_page(host_url, api_key, "json")
         else:
             status_code = res.status_code
             error_message = f"Unexpected response with error code {res.status_code}: {res.text}"

--- a/buildarr_sonarr/api.py
+++ b/buildarr_sonarr/api.py
@@ -42,19 +42,20 @@ logger = getLogger(__name__)
 INITIALIZE_JS_RES_PATTERN = re.compile(r"(?s)^window\.Sonarr = ({.*});$")
 
 
-def get_initialize_js(host_url: str, api_key: Optional[str] = None) -> Dict[str, Any]:
+def get_initialize_js(host_url: str, api_key: Optional[str] = None, file_extension: str = "js") -> Dict[str, Any]:
     """
     Get the Sonarr session initialisation metadata, including the API key.
 
     Args:
         host_url (str): Sonarr instance URL.
         api_key (str): Sonarr instance API key, if required. Defaults to `None`.
+        file_extension (str): File extension from the initialize page. Defaults to `js`.
 
     Returns:
         Session initialisation metadata
     """
 
-    url = f"{host_url}/initialize.js"
+    url = f"{host_url}/initialize.{file_extension}"
 
     logger.debug("GET %s", url)
 
@@ -70,6 +71,9 @@ def get_initialize_js(host_url: str, api_key: Optional[str] = None) -> Dict[str,
         if res.status_code in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FOUND):
             status_code: int = HTTPStatus.UNAUTHORIZED
             error_message = "Unauthorized"
+        elif res.status_code == HTTPStatus.NOT_FOUND and file_extension == "js":
+            logger.debug("Initialize page not found, perhaps running Sonarr v4? Retrying...")
+            return get_initialize_js(host_url, api_key, "json")
         else:
             status_code = res.status_code
             error_message = f"Unexpected response with error code {res.status_code}: {res.text}"
@@ -77,6 +81,10 @@ def get_initialize_js(host_url: str, api_key: Optional[str] = None) -> Dict[str,
             f"Unable to retrieve '{url}': {error_message}",
             status_code=status_code,
         )
+        
+    logger.debug("GET %s -> status_code=%i res=%s", url, res.status_code, repr(res.text))
+    if file_extension == "json":
+        return res.json()
 
     res_match = re.match(INITIALIZE_JS_RES_PATTERN, res.text)
     if not res_match:
@@ -84,11 +92,7 @@ def get_initialize_js(host_url: str, api_key: Optional[str] = None) -> Dict[str,
             f"No matches for 'initialize.js' parsing: {res.text}",
             status_code=res.status_code,
         )
-    res_json = json5.loads(res_match.group(1))
-
-    logger.debug("GET %s -> status_code=%i res=%s", url, res.status_code, repr(res_json))
-
-    return res_json
+    return json5.loads(res_match.group(1))
 
 
 def api_get(

--- a/buildarr_sonarr/config/general.py
+++ b/buildarr_sonarr/config/general.py
@@ -39,6 +39,7 @@ class AuthenticationMethod(BaseEnum):
     none = "none"
     basic = "basic"
     form = "forms"
+    external = "external"
 
 
 class CertificateValidation(BaseEnum):
@@ -196,6 +197,7 @@ class SecurityGeneralSettings(GeneralSettings):
     Values:
 
     * `none` - No authentication
+    * `external` - No authentication (Sonarr v4 only)
     * `basic` - Authentication using HTTP basic auth (browser popup)
     * `form` - Authentication using a login page
 

--- a/buildarr_sonarr/secrets.py
+++ b/buildarr_sonarr/secrets.py
@@ -25,7 +25,7 @@ from buildarr.secrets import SecretsPlugin
 from buildarr.types import NonEmptyStr, Port
 from pydantic import field_validator
 
-from .api import api_get, get_initialize_js
+from .api import api_get, get_initialize_page
 from .exceptions import SonarrAPIError, SonarrSecretsUnauthorizedError
 from .types import SonarrApiKey, SonarrProtocol
 
@@ -103,7 +103,7 @@ class SonarrSecrets(SecretsPlugin["SonarrConfig"]):
         )
         if not api_key:
             try:
-                initialize_js = get_initialize_js(host_url)
+                initialize_data = get_initialize_page(host_url)
             except SonarrAPIError as err:
                 if err.status_code == HTTPStatus.UNAUTHORIZED:
                     raise SonarrSecretsUnauthorizedError(
@@ -118,7 +118,7 @@ class SonarrSecrets(SecretsPlugin["SonarrConfig"]):
                 else:
                     raise
             else:
-                api_key = initialize_js["apiKey"]
+                api_key = initialize_data["apiKey"]
         try:
             system_status = cast(
                 Dict[str, Any],


### PR DESCRIPTION
First, thanks for the good work. 
I am using this project with Sonnar v4  and encountered some minor issues:
1. The initializiation page changed from `/initialize.js` to `/initialize.json`
2. Auth method `None` is now `External`

What I did for to solve the first problem was to try to fetch the `.js` page first and if the status code is 404 try the `.json` one

This is a baby step towards adding support for v4 #7 